### PR TITLE
Helper method to set temporary DOM context.

### DIFF
--- a/source/WebNavigator/Navigator.php
+++ b/source/WebNavigator/Navigator.php
@@ -13,6 +13,9 @@ class Navigator {
     /** @var int */
     private $_waitTimeout;
 
+    /** @var string|null */
+    private $_locatorPrefix;
+
     /**
      * @param \WebDriver $driver
      * @param string     $baseUrl
@@ -37,6 +40,28 @@ class Navigator {
 
     public function quit() {
         $this->_webDriver->quit();
+    }
+
+    /**
+     * @param string        $locator
+     * @param callable|null $block fn(Navigator)
+     */
+    public function scope($locator, callable $block = null) {
+        $locator = (string) $locator;
+        if (null === $block) {
+            $this->_locatorPrefix = $locator;
+        } else {
+            $navigator = clone $this;
+            $navigator->scope($locator);
+            $block($navigator);
+        }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLocatorPrefix() {
+        return $this->_locatorPrefix;
     }
 
     /**
@@ -224,6 +249,9 @@ class Navigator {
      * @return \WebDriverBy
      */
     protected function _getLocator($locator) {
+        if (null !== $this->_locatorPrefix) {
+            $locator = $this->_locatorPrefix . ' ' . $locator;
+        }
         return \WebDriverBy::cssSelector($locator);
     }
 }

--- a/source/WebNavigator/Navigator.php
+++ b/source/WebNavigator/Navigator.php
@@ -43,16 +43,16 @@ class Navigator {
     }
 
     /**
-     * @param string        $locator
+     * @param string        $locatorPrefix
      * @param callable|null $block fn(Navigator)
      */
-    public function scope($locator, callable $block = null) {
-        $locator = (string) $locator;
+    public function scope($locatorPrefix, callable $block = null) {
+        $locatorPrefix = (string) $locatorPrefix;
         if (null === $block) {
-            $this->_locatorPrefix = $locator;
+            $this->_locatorPrefix = $locatorPrefix;
         } else {
             $navigator = clone $this;
-            $navigator->scope($locator);
+            $navigator->scope($locatorPrefix);
             $block($navigator);
         }
     }

--- a/tests/data/test-scope.html
+++ b/tests/data/test-scope.html
@@ -1,0 +1,11 @@
+<html>
+  <body>
+
+    <span class="text">Test1</span>
+
+    <div id="id-scope">
+      <span class="text">Test2</span>
+    </div>
+
+  </body>
+</html>

--- a/tests/source/WebNavigatorTests/NavigatorTest.php
+++ b/tests/source/WebNavigatorTests/NavigatorTest.php
@@ -2,6 +2,8 @@
 
 namespace WebNavigatorTests;
 
+use WebNavigator\Navigator;
+
 class NavigatorTest extends TestCase {
 
     public function testScope() {

--- a/tests/source/WebNavigatorTests/NavigatorTest.php
+++ b/tests/source/WebNavigatorTests/NavigatorTest.php
@@ -6,6 +6,23 @@ use WebNavigator\Navigator;
 
 class NavigatorTest extends TestCase {
 
+    public function testScope() {
+        $this->_navigator->get('/test-scope.html');
+        $this->assertSame(null, $this->_navigator->getLocatorPrefix());
+        $this->assertSame('Test1', $this->_navigator->getText('.text'));
+
+        $this->_navigator->scope('#id-scope');
+        $this->assertSame('#id-scope', $this->_navigator->getLocatorPrefix());
+        $this->assertSame('Test2', $this->_navigator->getText('.text'));
+    }
+
+    public function testScopeWithBlock() {
+        $this->_navigator->scope('.foo', function(Navigator $navigator) {
+            $this->assertSame('.foo', $navigator->getLocatorPrefix());
+        });
+        $this->assertSame(null, $this->_navigator->getLocatorPrefix());
+    }
+
     public function testGetUrl() {
         $this->_navigator->get('/foo');
         $this->assertStringEndsWith('/foo', $this->_navigator->getUrl());

--- a/tests/source/WebNavigatorTests/TestCase.php
+++ b/tests/source/WebNavigatorTests/TestCase.php
@@ -10,14 +10,21 @@ class TestCase extends \PHPUnit_Framework_TestCase {
     protected $_navigator;
 
     public function setUp() {
-        $capabilities = new \DesiredCapabilities([\WebDriverCapabilityType::BROWSER_NAME => 'phantomjs']);
-        $driver = \RemoteWebDriver::create('http://localhost:4444/wd/hub', $capabilities);
-        $this->_navigator = new Navigator($driver, 'http://localhost:1234');
+        $this->_navigator = $this->_createNavigator();
     }
 
     public function tearDown() {
         if (isset($this->_navigator)) {
             $this->_navigator->quit();
         }
+    }
+
+    /**
+     * @return Navigator
+     */
+    protected function _createNavigator() {
+        $capabilities = new \DesiredCapabilities([\WebDriverCapabilityType::BROWSER_NAME => 'phantomjs']);
+        $driver = \RemoteWebDriver::create('http://localhost:4444/wd/hub', $capabilities);
+        return new Navigator($driver, 'http://localhost:1234');
     }
 }


### PR DESCRIPTION
Currently I have to write:
```php
$this->assertEmpty($this->_navigator->getText('.SK_Form_SignUp .CM_FormField_Location .messages'));
$this->assertEmpty($this->_navigator->getText('.SK_Form_SignUp .CM_FormField_Email .messages'));
$this->assertEmpty($this->_navigator->getText('.SK_Form_SignUp .SK_FormField_Username .messages'));
$this->assertEmpty($this->_navigator->getText('.SK_Form_SignUp .CM_FormField_Password .messages'));
```

Would be nice shorten it to
```php
$this->setTempDomContext('.SK_Form_SignUp');
$this->assertEmpty($this->_navigator->getText('.CM_FormField_Location .messages'));
$this->assertEmpty($this->_navigator->getText('.CM_FormField_Email .messages'));
$this->assertEmpty($this->_navigator->getText('.SK_FormField_Username .messages'));
$this->assertEmpty($this->_navigator->getText('.CM_FormField_Password .messages'));
$this->resetDomContext();
```