### PR TITLE
Control timeout amount in wait functionality.

### DIFF
--- a/source/WebNavigator/Navigator.php
+++ b/source/WebNavigator/Navigator.php
@@ -62,26 +62,28 @@ class Navigator {
     }
 
     /**
-     * @param string $locator
-     * @throws \Exception
-     * @throws \NoSuchElementException
-     * @throws \TimeOutException
+     * @param string   $locator
+     * @param int|null $timeout
      */
-    public function waitForElement($locator) {
-        $this->_waitUntil(\WebDriverExpectedCondition::presenceOfElementLocated($this->_getLocator($locator)));
+    public function waitForElement($locator, $timeout = null) {
+        $this->_waitUntil(\WebDriverExpectedCondition::presenceOfElementLocated($this->_getLocator($locator)), $timeout);
     }
 
     /**
      * @param string $javascript
+     * @param int|null $timeout
      */
-    public function waitForJs($javascript) {
+    public function waitForJs($javascript, $timeout = null) {
         $this->_waitUntil(function (\JavaScriptExecutor $driver) use ($javascript) {
             return $driver->executeScript($javascript);
-        });
+        }, $timeout);
     }
 
-    public function waitForAjax() {
-        $this->waitForJs('return (0 === $.active);');
+    /**
+     * @param int|null $timeout
+     */
+    public function waitForAjax($timeout = null) {
+        $this->waitForJs('return (0 === $.active);', $timeout);
     }
 
     /**
@@ -204,9 +206,13 @@ class Navigator {
 
     /**
      * @param \Closure|\WebDriverExpectedCondition $functionOrCondition
+     * @param int|null $timeout
      */
-    protected function _waitUntil($functionOrCondition) {
-        $this->_webDriver->wait($this->_waitTimeout)->until($functionOrCondition);
+    protected function _waitUntil($functionOrCondition, $timeout = null) {
+        if (null === $timeout) {
+            $timeout = $this->_waitTimeout;
+        }
+        $this->_webDriver->wait($timeout)->until($functionOrCondition);
     }
 
     /**

--- a/tests/source/WebNavigatorTests/NavigatorTest.php
+++ b/tests/source/WebNavigatorTests/NavigatorTest.php
@@ -64,6 +64,20 @@ class NavigatorTest extends TestCase {
         $this->assertSame('foo', $this->_navigator->executeJs('return window.myVariable'));
     }
 
+    /**
+     * @expectedException \TimeOutException
+     */
+    public function testWaitForJsWithTimeout() {
+        $this->_navigator->get('/test1.html');
+
+        $this->_navigator->executeJs('
+            setTimeout(function(){
+                window.myVariable = "foo";
+            }, 2000);'
+        );
+        $this->_navigator->waitForJs('return (window.myVariable === "foo")', 1);
+    }
+
     public function testWaitForAjax() {
         $this->_navigator->get('/test-jquery.html');
 


### PR DESCRIPTION
There are cases when the default timeout is not enough and you need to wait more. For example, uploading a file. So, it would be good to offer a control on timeout for the end-user developer of webnavigator. It would be good to have an ability to control the global timeout and the local one too. So, in the beginning of a test suite you could increase the timeout for the whole test suite or just a local test, if needed.